### PR TITLE
normalize strings based on the char map in the current font (if present)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::convert::TryInto;
 
 use pdf::{content::Operation as PdfOperation, primitive::Primitive};
+use pdf::encoding::BaseEncoding;
+use pdf::font::Font;
+use pdf::object::RcRef;
+use pdf::primitive::PdfString;
 
 pub struct Name<'src>(&'src str);
 
@@ -199,7 +205,50 @@ impl PrimitiveExt for Primitive {
     }
 }
 
+pub struct FontInfo {
+    pub font: RcRef<Font>,
+    pub cmap: HashMap<u16, String>
+}
+
+fn normalize_string<'a>(text: &'a PdfString, current_font: Option<&FontInfo>) -> pdf::error::Result<Cow<'a, str>> {
+    match current_font {
+        Some(cf) => match cf.font.encoding() {
+            Some(encoding) => {
+                match encoding.base {
+                    BaseEncoding::IdentityH => {
+                        let mut out: String = "".to_string();
+                        for w in text.as_bytes().windows(2) {
+                            let cp = u16::from_be_bytes(w.try_into().unwrap());
+                            if let Some(s) = cf.cmap.get(&cp) {
+                                out.push_str(s);
+                            }
+                        }
+                        Ok(Cow::from(out))
+                    }
+                    _ => {
+                        let mut out: String = "".to_string();
+                        for &b in text.as_bytes() {
+                            if let Some(s) = cf.cmap.get(&(b as u16)) {
+                                out.push_str(s);
+                            } else {
+                                out.push(b as char);
+                            }
+                        }
+                        Ok(Cow::from(out))
+                    }
+                }
+            }
+            None => text.as_str()
+        }
+        None => text.as_str()
+    }
+}
+
 pub fn normalize_operation(operation: &PdfOperation) -> Operation {
+    normalize_operation_with_font(operation, None)
+}
+
+pub fn normalize_operation_with_font<'a>(operation: &'a PdfOperation, current_font: Option<&FontInfo>) -> Operation<'a> {
     let PdfOperation { operator, operands } = operation;
 
     match (operator.as_str(), operands.as_slice()) {
@@ -594,16 +643,17 @@ pub fn normalize_operation(operation: &PdfOperation) -> Operation {
                 size: *size as f32,
             }
         }
-        ("Tj", [Primitive::String(text)]) => text
-            .as_str()
-            .map(Operation::ShowText)
-            .unwrap_or_else(|_| Operation::Unknown { operator, operands }),
+        ("Tj", [Primitive::String(text)]) => {
+            normalize_string(text, current_font)
+                .map(Operation::ShowText)
+                .unwrap_or_else(|_| Operation::Unknown { operator, operands })
+        },
         ("TJ", [Primitive::Array(primitive_array)]) => {
             let array = primitive_array
                 .iter()
                 .filter_map(|primitive| match primitive {
                     Primitive::String(string) => {
-                        string.as_str().ok().map(TextOrGlyphPositioning::Text)
+                        normalize_string(string, current_font).ok().map(TextOrGlyphPositioning::Text)
                     }
                     Primitive::Number(glyph_positioning) => {
                         Some(TextOrGlyphPositioning::GlyphPositioning(*glyph_positioning))
@@ -696,15 +746,14 @@ pub fn normalize_operation(operation: &PdfOperation) -> Operation {
                 Operation::Unknown { operator, operands }
             }
         }
-        ("'", [Primitive::String(text)]) => text
-            .as_str()
+        ("'", [Primitive::String(text)]) => normalize_string(text, current_font)
             .map(Operation::MoveToNextLineAndShowText)
             .unwrap_or_else(|_| Operation::Unknown { operator, operands }),
         ("\"", [word_spacing, character_spacing, Primitive::String(text)]) => {
             if let (Some(word_spacing), Some(character_spacing), Ok(text)) = (
                 word_spacing.try_to_f(),
                 character_spacing.try_to_f(),
-                text.as_str(),
+                normalize_string(text, current_font),
             ) {
                 Operation::SetWordAndCharacterSpacingMoveToNextLineAndShowText {
                     word_spacing,


### PR DESCRIPTION
This is mostly copied from the "text" example of the "pdf" crate, based on work by @s3bk
https://github.com/pdf-rs/pdf/blob/master/examples/text/src/main.rs

The FontInfo struct is created there as a way to cache the character maps retrieved from the Font resources. Unfortunately it's not part of the main codebase of the lib, it's just in the examples, so I can't import it and had to copy it as well. It looks like the handling of character maps is not mature enough yet (based on the comment in line 24), but for my use-case it was working fine, so I wanted to integrate it with the nicely typed Operations from this crate.

I think the parsing of the Fonts is not really in the scope of this crate, but it would be really useful to use them if present.